### PR TITLE
LiteMath little mistake fix

### DIFF
--- a/hydra_api/LiteMath.h
+++ b/hydra_api/LiteMath.h
@@ -31,7 +31,7 @@ namespace HydraLiteMath
   {
     float3() :x(0), y(0), z(0) {}
     float3(float a, float b, float c) : x(a), y(b), z(c) {}
-    float3(const float* ptr) : x(ptr[0]), y(ptr[1]), z(ptr[0]) {}
+    float3(const float* ptr) : x(ptr[0]), y(ptr[1]), z(ptr[2]) {}
 
     float x, y, z;
   };


### PR DESCRIPTION
Third component of float3 vector should be ptr[2] instead of ptr[0]